### PR TITLE
Improve debug mode email sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ users:
 ```
 
 `notify_in_debug` allows selected users to still receive mails when the
-`debug` flag is enabled.
+`debug` flag is enabled. In this mode the script prints additional
+information about which mails are prepared or skipped.
 
 ## Usage
 

--- a/src/ninox_notification/emailer.py
+++ b/src/ninox_notification/emailer.py
@@ -9,14 +9,14 @@ class Emailer:
         self.config = config
         self.debug = debug
 
-    def send(self, recipient: str, subject: str, html_body: str):
+    def send(self, recipient: str, subject: str, html_body: str, *, force_send: bool = False):
         msg = EmailMessage()
         msg["From"] = self.config.from_address
         msg["To"] = recipient
         msg["Subject"] = subject
         msg.set_content(html_body, subtype="html")
 
-        if self.debug:
+        if self.debug and not force_send:
             print(f"[DEBUG] Would send email to {recipient}: {subject}")
             return
 

--- a/src/ninox_notification/notify.py
+++ b/src/ninox_notification/notify.py
@@ -39,12 +39,25 @@ def main(config_path: str):
 
     for username, user_cfg in cfg.users.items():
         user_tasks = tasks_by_user.get(username, [])
+
         if cfg.debug and not user_cfg.notify_in_debug:
+            print(f"[DEBUG] Skip {username} (notify_in_debug is False)")
             continue
+
+        if cfg.debug:
+            print(
+                f"[DEBUG] Preparing email for {username} with {len(user_tasks)} tasks"
+            )
+
         body = f"<h3>Offene Aufgaben ({len(user_tasks)})</h3>" + format_tasks(user_tasks)
         subject = "Deine offenen Aufgaben"
         try:
-            emailer.send(user_cfg.email, subject, body)
+            emailer.send(
+                user_cfg.email,
+                subject,
+                body,
+                force_send=cfg.debug and user_cfg.notify_in_debug,
+            )
         except Exception as exc:
             print(f"Failed to send mail to {user_cfg.email}: {exc}")
 


### PR DESCRIPTION
## Summary
- allow forcing email send when debug is enabled
- log skipped users when in debug mode
- mention new behaviour in README

## Testing
- `pytest -q`