### PR TITLE
Update to Ninox email fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 This project fetches all active tasks (everything that is not completed)
 from a Ninox database and sends a daily summary email to each user.
-Configuration is done via a YAML file.
+Configuration is done via a YAML file. Email addresses of the assignees are
+now read directly from the Ninox table `Personen` and no longer defined in the
+configuration file.
 
 ## Configuration
 
@@ -24,21 +26,9 @@ smtp:
   password: "pass"
   from_address: "todo@example.com"
 
-users:
-  "André Bogatz":
-    email: "andre@example.com"
-    notify_in_debug: true
-  "Philipp Kabelka":
-    email: "philipp@example.com"
-    notify_in_debug: false
-
   send_time: "09:00"  # when the internal scheduler triggers
   debug: false         # set true to avoid sending mails
 ```
-
-`notify_in_debug` allows selected users to still receive mails when the
-`debug` flag is enabled. In this mode the script prints additional
-information about which mails are prepared or skipped.
 
 ## Usage
 

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -12,13 +12,5 @@ smtp:
   password: "pass"
   from_address: "todo@example.com"
 
-users:
-  "André Bogatz":
-    email: "andre@example.com"
-    notify_in_debug: true
-  "Philipp Kabelka":
-    email: "philipp@example.com"
-    notify_in_debug: false
-
 send_time: "09:00"  # daily notification time
 debug: false

--- a/src/ninox_notification/config.py
+++ b/src/ninox_notification/config.py
@@ -1,6 +1,5 @@
 import yaml
 from dataclasses import dataclass
-from typing import Dict, Any
 
 
 @dataclass
@@ -22,16 +21,9 @@ class NinoxConfig:
 
 
 @dataclass
-class User:
-    email: str
-    notify_in_debug: bool = False
-
-
-@dataclass
 class Config:
     ninox: NinoxConfig
     smtp: SMTPConfig
-    users: Dict[str, User]
     send_time: str = "09:00"
     debug: bool = False
 
@@ -47,8 +39,7 @@ def load_config(path: str) -> Config:
 
     ninox = NinoxConfig(**data["ninox"])
     smtp = SMTPConfig(**data["smtp"])
-    users = {name: User(**info) for name, info in data["users"].items()}
     send_time = data.get("send_time", "09:00")
     debug = data.get("debug", False)
 
-    return Config(ninox=ninox, smtp=smtp, users=users, send_time=send_time, debug=debug)
+    return Config(ninox=ninox, smtp=smtp, send_time=send_time, debug=debug)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,15 +14,11 @@ smtp:
   username: user
   password: pass
   from_address: from@example.com
-users:
-  Alice:
-    email: alice@example.com
 """
 
 def test_load_config():
     with tempfile.NamedTemporaryFile('w+', delete=False) as tmp:
         tmp.write(SAMPLE)
         tmp.flush()
-        cfg = load_config(tmp.name)
+    cfg = load_config(tmp.name)
     assert cfg.ninox.team_id == 'T'
-    assert 'Alice' in cfg.users

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -18,17 +18,14 @@ CONFIG = {
         'password': '',
         'from_address': 'from@example.com',
     },
-    'users': {
-        'Bob': {'email': 'bob@example.com', 'notify_in_debug': True},
-    },
     'debug': True,
 }
 
 SAMPLE_TASK = {
     'fields': {
         'Aufgabe': 'Test',
-        'Person': 'Bob',
-        'Von': 'Alice',
+        'Aufgabe für': 'Bob',
+        'Aufgabe von': 'Alice',
         'Kategorie': 'Cat',
         'Notizen': 'Line1\nLine2',
         'Status': 'in Bearbeitung',
@@ -42,11 +39,12 @@ def test_notify_sends_mail():
         yaml.safe_dump(CONFIG, tmp)
         tmp.flush()
         with patch('ninox_notification.ninox_client.NinoxClient.get_tasks', return_value=[SAMPLE_TASK]):
-            with patch('ninox_notification.emailer.Emailer.send') as send:
-                main(tmp.name)
-                send.assert_called_once()
-                args, _ = send.call_args
-                html = args[2]
-                assert '<th>Status</th>' in html
-                assert '01.01.2024' in html
-                assert "<tr><td colspan='" in html
+            with patch('ninox_notification.ninox_client.NinoxClient.get_persons', return_value=[{'fields': {'fullName': 'Bob', 'E-Mail': 'bob@example.com'}}]):
+                with patch('ninox_notification.emailer.Emailer.send') as send:
+                    main(tmp.name)
+                    send.assert_called_once()
+                    args, _ = send.call_args
+                    html = args[2]
+                    assert '<th>Status</th>' in html
+                    assert '01.01.2024' in html
+                    assert "<tr><td colspan='" in html


### PR DESCRIPTION
## Summary
- remove user definitions from config
- fetch assignee addresses from Ninox `Personen` table
- switch task processing to use `Aufgabe für` and `Aufgabe von`
- update docs and examples
- adjust tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687562005114832bb387ca8386bdceb3