### PR TITLE
Enable real emails for a debug user

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ smtp:
 
   send_time: "09:00"  # when the internal scheduler triggers
   debug: false         # set true to avoid sending mails
+  debug_user: ""       # optional, send real mail only for this user in debug mode
 ```
 
 ## Usage

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -14,3 +14,4 @@ smtp:
 
 send_time: "09:00"  # daily notification time
 debug: false
+debug_user: ""  # when debug is true, send only for this user

--- a/src/ninox_notification/config.py
+++ b/src/ninox_notification/config.py
@@ -1,5 +1,6 @@
 import yaml
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass
@@ -26,6 +27,7 @@ class Config:
     smtp: SMTPConfig
     send_time: str = "09:00"
     debug: bool = False
+    debug_user: Optional[str] = None
 
 
 def load_config(path: str) -> Config:
@@ -41,5 +43,11 @@ def load_config(path: str) -> Config:
     smtp = SMTPConfig(**data["smtp"])
     send_time = data.get("send_time", "09:00")
     debug = data.get("debug", False)
-
-    return Config(ninox=ninox, smtp=smtp, send_time=send_time, debug=debug)
+    debug_user = data.get("debug_user")
+    return Config(
+        ninox=ninox,
+        smtp=smtp,
+        send_time=send_time,
+        debug=debug,
+        debug_user=debug_user,
+    )

--- a/src/ninox_notification/notify.py
+++ b/src/ninox_notification/notify.py
@@ -104,6 +104,10 @@ def main(config_path: str):
     for username, user_tasks in tasks_by_user.items():
         user_tasks.sort(key=_task_sort_key)
 
+        if cfg.debug and cfg.debug_user and username != cfg.debug_user:
+            print(f"[DEBUG] Skipping {username}, not debug user")
+            continue
+
         recipient = email_map.get(username)
         if not recipient:
             if cfg.debug:
@@ -116,7 +120,12 @@ def main(config_path: str):
         body = f"<h3>Offene Aufgaben ({len(user_tasks)})</h3>" + format_tasks(user_tasks)
         subject = "Deine offenen Aufgaben"
         try:
-            emailer.send(recipient, subject, body)
+            emailer.send(
+                recipient,
+                subject,
+                body,
+                force_send=cfg.debug and username == cfg.debug_user,
+            )
         except Exception as exc:
             print(f"Failed to send mail to {recipient}: {exc}")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,7 +18,8 @@ smtp:
 
 def test_load_config():
     with tempfile.NamedTemporaryFile('w+', delete=False) as tmp:
-        tmp.write(SAMPLE)
+        tmp.write(SAMPLE + "debug_user: Bob\n")
         tmp.flush()
     cfg = load_config(tmp.name)
     assert cfg.ninox.team_id == 'T'
+    assert cfg.debug_user == 'Bob'

--- a/tests/test_emailer.py
+++ b/tests/test_emailer.py
@@ -8,3 +8,11 @@ def test_emailer_debug():
     with patch('smtplib.SMTP') as smtp:
         emailer.send('a@example.com', 'sub', '<p>hi</p>')
         smtp.assert_not_called()
+
+
+def test_emailer_force_send_in_debug():
+    cfg = SMTPConfig(host='h', port=25, username='', password='', from_address='f')
+    emailer = Emailer(cfg, debug=True)
+    with patch('smtplib.SMTP') as smtp:
+        emailer.send('a@example.com', 'sub', '<p>hi</p>', force_send=True)
+        smtp.assert_called_once()

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -48,3 +48,38 @@ def test_notify_sends_mail():
                     assert '<th>Status</th>' in html
                     assert '01.01.2024' in html
                     assert "<tr><td colspan='" in html
+
+
+def test_notify_debug_user_only():
+    cfg = CONFIG.copy()
+    cfg['debug_user'] = 'Bob'
+    with tempfile.NamedTemporaryFile('w+', delete=False) as tmp:
+        yaml.safe_dump(cfg, tmp)
+        tmp.flush()
+        tasks = [
+            SAMPLE_TASK,
+            {
+                'fields': {
+                    'Aufgabe': 'Test2',
+                    'Aufgabe für': 'Alice',
+                    'Aufgabe von': 'Bob',
+                    'Kategorie': 'Cat',
+                    'Notizen': '',
+                    'Status': 'offen',
+                    'Priorität': 'normal',
+                    'Frist': '2024-01-02'
+                }
+            },
+        ]
+        persons = [
+            {'fields': {'fullName': 'Bob', 'E-Mail': 'bob@example.com'}},
+            {'fields': {'fullName': 'Alice', 'E-Mail': 'alice@example.com'}},
+        ]
+        with patch('ninox_notification.ninox_client.NinoxClient.get_tasks', return_value=tasks):
+            with patch('ninox_notification.ninox_client.NinoxClient.get_persons', return_value=persons):
+                with patch('ninox_notification.emailer.Emailer.send') as send:
+                    main(tmp.name)
+                    send.assert_called_once()
+                    args, kwargs = send.call_args
+                    assert kwargs['force_send'] is True
+                    assert args[0] == 'bob@example.com'


### PR DESCRIPTION
## Summary
- allow specifying a `debug_user` in the configuration
- send a real email to that user when running in debug mode
- document the new setting
- test forced sending and debug-only behaviour

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68756a0c94b0832bba51c80174fd646b