### PR TITLE
Make persons table configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ ninox:
   team_id: "TEAM_ID"
   database_id: "DATABASE_ID"
   table_id: "TABLE_ID"
+  persons_table_id: "PERSONS_TABLE_ID"
   api_token: "TOKEN"
 
 smtp:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ smtp:
 
   send_time: "09:00"  # when the internal scheduler triggers
   debug: false         # set true to avoid sending mails
+  debug_user: ""       # optional, send real mail only for this user in debug mode
 ```
 
 ## Usage

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -15,3 +15,4 @@ smtp:
 
 send_time: "09:00"  # daily notification time
 debug: false
+debug_user: ""  # when debug is true, send only for this user

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -3,6 +3,7 @@ ninox:
   team_id: "TEAM_ID"
   database_id: "DATABASE_ID"
   table_id: "TABLE_ID"
+  persons_table_id: "PERSONS_TABLE_ID"
   api_token: "TOKEN"
 
 smtp:

--- a/src/ninox_notification/config.py
+++ b/src/ninox_notification/config.py
@@ -1,5 +1,6 @@
 import yaml
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass
@@ -27,6 +28,7 @@ class Config:
     smtp: SMTPConfig
     send_time: str = "09:00"
     debug: bool = False
+    debug_user: Optional[str] = None
 
 
 def load_config(path: str) -> Config:
@@ -43,5 +45,12 @@ def load_config(path: str) -> Config:
     smtp = SMTPConfig(**data["smtp"])
     send_time = data.get("send_time", "09:00")
     debug = data.get("debug", False)
+    debug_user = data.get("debug_user")
 
-    return Config(ninox=ninox, smtp=smtp, send_time=send_time, debug=debug)
+    return Config(
+        ninox=ninox,
+        smtp=smtp,
+        send_time=send_time,
+        debug=debug,
+        debug_user=debug_user,
+    )

--- a/src/ninox_notification/config.py
+++ b/src/ninox_notification/config.py
@@ -17,6 +17,7 @@ class NinoxConfig:
     team_id: str
     database_id: str
     table_id: str
+    persons_table_id: str
     api_token: str
 
 
@@ -37,7 +38,8 @@ def load_config(path: str) -> Config:
     except yaml.YAMLError as e:
         raise ValueError(f"Invalid YAML in {path}: {e}")
 
-    ninox = NinoxConfig(**data["ninox"])
+    ninox_data = data["ninox"]
+    ninox = NinoxConfig(**ninox_data)
     smtp = SMTPConfig(**data["smtp"])
     send_time = data.get("send_time", "09:00")
     debug = data.get("debug", False)

--- a/src/ninox_notification/ninox_client.py
+++ b/src/ninox_notification/ninox_client.py
@@ -61,11 +61,13 @@ class NinoxClient:
 
     def get_persons(
         self,
-        table_id: str = "VC",
+        table_id: str | None = None,
         *,
         active_only: bool = True,
     ) -> List[Dict[str, Any]]:
         """Return persons from the given Ninox table."""
+        if table_id is None:
+            table_id = self.config.persons_table_id
         records = []
         page = 0
         per_page = 100

--- a/src/ninox_notification/notify.py
+++ b/src/ninox_notification/notify.py
@@ -104,6 +104,10 @@ def main(config_path: str):
     for username, user_tasks in tasks_by_user.items():
         user_tasks.sort(key=_task_sort_key)
 
+        if cfg.debug and cfg.debug_user and username != cfg.debug_user:
+            print(f"[DEBUG] Skipping {username}, not debug user")
+            continue
+
         recipient = email_map.get(username)
         if not recipient:
             if cfg.debug:
@@ -116,7 +120,12 @@ def main(config_path: str):
         body = f"<h3>Offene Aufgaben ({len(user_tasks)})</h3>" + format_tasks(user_tasks)
         subject = "Deine offenen Aufgaben"
         try:
-            emailer.send(recipient, subject, body)
+            emailer.send(
+                recipient,
+                subject,
+                body,
+                force_send=cfg.debug and username == cfg.debug_user,
+            )
         except Exception as exc:
             print(f"Failed to send mail to {recipient}: {exc}")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,6 +7,7 @@ ninox:
   team_id: T
   database_id: D
   table_id: F
+  persons_table_id: P
   api_token: TOKEN
 smtp:
   host: smtp
@@ -22,3 +23,4 @@ def test_load_config():
         tmp.flush()
     cfg = load_config(tmp.name)
     assert cfg.ninox.team_id == 'T'
+    assert cfg.ninox.persons_table_id == 'P'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,8 +19,9 @@ smtp:
 
 def test_load_config():
     with tempfile.NamedTemporaryFile('w+', delete=False) as tmp:
-        tmp.write(SAMPLE)
+        tmp.write(SAMPLE + "debug_user: Bob\n")
         tmp.flush()
     cfg = load_config(tmp.name)
     assert cfg.ninox.team_id == 'T'
     assert cfg.ninox.persons_table_id == 'P'
+    assert cfg.debug_user == 'Bob'

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -9,6 +9,7 @@ CONFIG = {
         'team_id': 't',
         'database_id': 'd',
         'table_id': 'f',
+        'persons_table_id': 'p',
         'api_token': 'tok',
     },
     'smtp': {


### PR DESCRIPTION
## Summary
- add `persons_table_id` option to configuration
- use configured ID in Ninox client
- update config example and README
- update tests

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68756ab73cbc832bba50059ccc54b3f2