### PR TITLE
Read persons table from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ ninox:
   team_id: "TEAM_ID"
   database_id: "DATABASE_ID"
   table_id: "TABLE_ID"
+  person_table_id: "PERSON_TABLE_ID"
   api_token: "TOKEN"
 
 smtp:

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -3,6 +3,7 @@ ninox:
   team_id: "TEAM_ID"
   database_id: "DATABASE_ID"
   table_id: "TABLE_ID"
+  person_table_id: "PERSON_TABLE_ID"
   api_token: "TOKEN"
 
 smtp:

--- a/src/ninox_notification/config.py
+++ b/src/ninox_notification/config.py
@@ -18,6 +18,7 @@ class NinoxConfig:
     team_id: str
     database_id: str
     table_id: str
+    person_table_id: str
     api_token: str
 
 

--- a/src/ninox_notification/ninox_client.py
+++ b/src/ninox_notification/ninox_client.py
@@ -61,11 +61,13 @@ class NinoxClient:
 
     def get_persons(
         self,
-        table_id: str = "VC",
+        table_id: str | None = None,
         *,
         active_only: bool = True,
     ) -> List[Dict[str, Any]]:
         """Return persons from the given Ninox table."""
+        if table_id is None:
+            table_id = self.config.person_table_id
         records = []
         page = 0
         per_page = 100

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,6 +7,7 @@ ninox:
   team_id: T
   database_id: D
   table_id: F
+  person_table_id: P
   api_token: TOKEN
 smtp:
   host: smtp

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -9,6 +9,7 @@ CONFIG = {
         'team_id': 't',
         'database_id': 'd',
         'table_id': 'f',
+        'person_table_id': 'p',
         'api_token': 'tok',
     },
     'smtp': {


### PR DESCRIPTION
## Summary
- add person_table_id option in config and example
- document new config value in README
- update NinoxClient to read person table from config
- adjust tests for new config option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68756f9e6a44832bbded999297643205