### PR TITLE
Remove notes from task table and show count in subject

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ the configured `send_time`.
 ### Email output
 
 * Tasks include their current status and who created them.
-* Notes are shown in a separate row spanning the whole table for better
-  readability.
+* Notes are no longer included in the table to keep the email concise.
 * Due dates are formatted as `DD.MM.YYYY` and highlighted in red when
   the task is overdue.

--- a/src/ninox_notification/notify.py
+++ b/src/ninox_notification/notify.py
@@ -54,7 +54,6 @@ th {background-color: #f2f2f2; text-align: left;}
     rows = []
     for t in tasks:
         f = t.get("fields", {})
-        notes = f.get("Notizen", "").replace("\n", "<br>")
 
         due_raw = f.get("Frist", "")
         due_formatted, overdue = _format_date(due_raw)
@@ -73,8 +72,6 @@ th {background-color: #f2f2f2; text-align: left;}
             f"<td>{f.get('Aufgabe für','')}</td></tr>"
         )
         rows.append(row)
-        if notes:
-            rows.append(f"<tr><td colspan='7'>{notes}</td></tr>")
 
     return header + "".join(rows) + "</table>"
 
@@ -118,7 +115,7 @@ def main(config_path: str):
             print(f"[DEBUG] Preparing email for {username} with {len(user_tasks)} tasks")
 
         body = f"<h3>Offene Aufgaben ({len(user_tasks)})</h3>" + format_tasks(user_tasks)
-        subject = "Deine offenen Aufgaben"
+        subject = f"Deine offenen Aufgaben ({len(user_tasks)})"
         try:
             emailer.send(
                 recipient,

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -46,9 +46,11 @@ def test_notify_sends_mail():
                     send.assert_called_once()
                     args, _ = send.call_args
                     html = args[2]
+                    subject = args[1]
                     assert '<th>Status</th>' in html
                     assert '01.01.2024' in html
-                    assert "<tr><td colspan='" in html
+                    assert "<tr><td colspan='" not in html
+                    assert subject == 'Deine offenen Aufgaben (1)'
 
 
 def test_notify_debug_user_only():
@@ -84,3 +86,4 @@ def test_notify_debug_user_only():
                     args, kwargs = send.call_args
                     assert kwargs['force_send'] is True
                     assert args[0] == 'bob@example.com'
+                    assert args[1] == 'Deine offenen Aufgaben (1)'


### PR DESCRIPTION
## Summary
- drop task notes from email table for clarity
- include the number of open tasks in the subject line
- update README
- adjust tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687574d34630832b939cb49ca7fb406e